### PR TITLE
Resolve after the success callback, to play nice with fetch.

### DIFF
--- a/Backbone.CrossDomain.js
+++ b/Backbone.CrossDomain.js
@@ -169,8 +169,8 @@
                     obj = Backbone.$.parseJSON(xdr.responseText);
                 }
                 if (obj) {
-                    if(deferred) deferred.resolveWith(this, [obj, 'success', xdr]);
                     success(obj);
+                    if(deferred) deferred.resolveWith(this, [obj, 'success', xdr]);
                 }
             };
             xdr.onerror = function () {


### PR DESCRIPTION
Hey there!

We had something like `@collection.fetch().then => …` and it was not working correctly because `fetch()` would resolve its deferred object (and call the function passed to `then`) before actually updating the model that was fetched. Inside the function passed to `then`, we were trying to access some of the data that `fetch` would've fetched, but it wasn't there yet because the `success` callback was not called.

Backbone updates the model in the `success` callback [here](https://github.com/jashkenas/backbone/blob/743ebb788d8909b277ca459c6c9159f9528b6f87/backbone.js#L451-L455).

I can provide a more in-depth example if desired.

Thanks!
