### PR TITLE
Append the 'data' parameters to the url of GET request

### DIFF
--- a/Backbone.CrossDomain.js
+++ b/Backbone.CrossDomain.js
@@ -153,6 +153,11 @@
                 params.data = Backbone.$.param(Backbone.$.parseJSON(params.data));
             }
 
+            // Append the .data parameters to the url of GET request
+            if (params.type === 'GET' && !_.include(params.url, '?') && options.data ){
+                params.url += '?' + Backbone.$.param(options.data);
+            }
+
             var xdr = options.xhr = new XDomainRequest(),
                 success = options.success,
                 error = options.error;


### PR DESCRIPTION
Allow to make GET requests with params, when you use methot 'fetch' like:

myCollectionInstance.fetch({data: {some: data, other: param}})

make GET request with URL http://#{model_url}?some=data&other=param

